### PR TITLE
Fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ const rollbarConfig = {
   accessToken: '<SECRET_TOKEN_HERE>',
   version: '1.0',
   baseUrl: 'yourwebsite.com',
-  ignoreUploadErrors = true,
+  ignoreUploadErrors: true,
   silent: true,
 }
 


### PR DESCRIPTION
Hello,

I am assessing migrating an app from create-react-app to Vite. And we use a plugin to upload source maps to Rollbar. Found your vite plugin and while following the documentation found this small typo.

Cheers,
Thank you for this plugin 🙇  